### PR TITLE
Update plugin-publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
     id 'maven'
     id 'signing'
-    id 'com.gradle.plugin-publish' version '0.9.1'
+    id 'com.gradle.plugin-publish' version '0.9.9'
 }
 
 description = 'Gradle plugin to find duplicate code using PMDs copy/paste detection (= CPD)'


### PR DESCRIPTION
Hiya, Tim from Gradle here.

There was a bug in versions prior to 0.9.7 of the gradle plugin-publish-plugin, where artifacts would sometimes silently not be pushed into the repo.

Your plugin has not been affected by the bug yet, but you should still upgrade.

Hope this helps!

Let me know here [or in the forums](https://discuss.gradle.org/c/help-discuss/plugin-portal) if you need more assistance.

Cheers,