### PR TITLE
The 'check' task is introduced by LifecycleBasePlugin

### DIFF
--- a/src/integTest/groovy/de/aaschmid/gradle/plugins/cpd/test/CpdIntegrationTest.groovy
+++ b/src/integTest/groovy/de/aaschmid/gradle/plugins/cpd/test/CpdIntegrationTest.groovy
@@ -35,7 +35,7 @@ class CpdIntegrationTest extends Specification {
         then:
         result.output.contains("BUILD SUCCESSFUL")
         result.task(':cpdCheck').outcome == NO_SOURCE
-        !result.output.contains('WARNING: Due to the absence of JavaBasePlugin on root project')
+        !result.output.contains('WARNING: Due to the absence of LifecycleBasePlugin on root project')
     }
 
     @Issue('https://github.com/aaschmid/gradle-cpd-plugin/issues/8')
@@ -54,7 +54,7 @@ class CpdIntegrationTest extends Specification {
         then:
         result.output.contains("BUILD SUCCESSFUL")
         result.task(':cpdCheck') == null
-        !result.output.contains('WARNING: Due to the absence of JavaBasePlugin on root project')
+        !result.output.contains('WARNING: Due to the absence of LifecycleBasePlugin on root project')
     }
 
     @Issue('https://github.com/aaschmid/gradle-cpd-plugin/issues/3')
@@ -83,7 +83,7 @@ class CpdIntegrationTest extends Specification {
 
         def rootProjectName = testProjectDir.root.name
         result.output.contains("""\
-WARNING: Due to the absence of JavaBasePlugin on root project '${rootProjectName}' the task ':cpdCheck' could not be\
+WARNING: Due to the absence of LifecycleBasePlugin on root project '${rootProjectName}' the task ':cpdCheck' could not be\
  added to task graph and therefore will not be executed. SUGGESTION: add a dependency to task ':cpdCheck' manually to a\
  subprojects 'check' task, e.g. to project ':sub' using
 
@@ -92,7 +92,7 @@ WARNING: Due to the absence of JavaBasePlugin on root project '${rootProjectName
 or to root project '${rootProjectName}' using
 
     project(':sub') {
-        plugins.withType(JavaBasePlugin) { // <- just required if 'java' plugin is applied within subproject
+        plugins.withType(LifecycleBasePlugin) { // <- just required if 'java' plugin is applied within subproject
             check.dependsOn(cpdCheck)
         }
     }
@@ -124,7 +124,7 @@ or to root project '${rootProjectName}' using
         then:
         result.output.contains("BUILD SUCCESSFUL")
         result.task(':cpdCheck').outcome == NO_SOURCE
-        !result.output.contains('WARNING: Due to the absence of JavaBasePlugin on root project')
+        !result.output.contains('WARNING: Due to the absence of LifecycleBasePlugin on root project')
     }
 
     @Issue('https://github.com/aaschmid/gradle-cpd-plugin/issues/10')

--- a/src/main/groovy/de/aaschmid/gradle/plugins/cpd/CpdPlugin.groovy
+++ b/src/main/groovy/de/aaschmid/gradle/plugins/cpd/CpdPlugin.groovy
@@ -11,6 +11,7 @@ import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.SourceSet
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 
 /**
@@ -27,7 +28,7 @@ import org.gradle.api.tasks.SourceSet
  * A {@link Cpd} task named {@code cpd} is created and configured with default options. It can be further configured
  * to analyze the source code you want, e.g. {@code source = project.files('src')}.
  * <p>
- * The created {@link Cpd} task is added to the {@code check} lifecycle task of {@link JavaBasePlugin} if it is also
+ * The created {@link Cpd} task is added to the {@code check} lifecycle task of {@link LifecycleBasePlugin} if it is also
  * applied, e.g. using {@link org.gradle.api.plugins.JavaPlugin}.
  * <p>
  * Sample:
@@ -86,7 +87,7 @@ class CpdPlugin implements Plugin<Project> {
                 }
             }
         }
-        project.plugins.withType(JavaBasePlugin){
+        project.plugins.withType(LifecycleBasePlugin){
             project.tasks.findByName('check').dependsOn(task)
         }
         project.gradle.taskGraph.whenReady{ TaskExecutionGraph graph ->
@@ -94,13 +95,13 @@ class CpdPlugin implements Plugin<Project> {
                 if (logger.isWarnEnabled()) {
                     def lastCheckTask = graph.allTasks.reverse().find{ t -> t.name.endsWith('check') }
                     if (lastCheckTask) { // it is possible to just execute a task before check, e.g. "compileJava"
-                        logger.warn("WARNING: Due to the absence of ${JavaBasePlugin.simpleName} on ${project}" +
+                        logger.warn("WARNING: Due to the absence of ${LifecycleBasePlugin.simpleName} on ${project}" +
                                 " the ${task} could not be added to task graph and therefore will not be executed" +
                                 ". SUGGESTION: add a dependency to ${task} manually to a subprojects 'check' task, e.g. to ${lastCheckTask.project} using\n\n" +
                                 "    ${lastCheckTask.name}.dependsOn('${task.path}')\n\n" +
                                 "or to ${project} using\n\n" +
                                 "    project('${lastCheckTask.project.path}') {\n" +
-                                "        plugins.withType(JavaBasePlugin) { // <- just required if 'java' plugin is applied within subproject\n" +
+                                "        plugins.withType(LifecycleBasePlugin) { // <- just required if 'java' plugin is applied within subproject\n" +
                                 "            ${lastCheckTask.name}.dependsOn(${task.name})\n" +
                                 "        }\n" +
                                 "    }\n")

--- a/src/test/groovy/de/aaschmid/gradle/plugins/cpd/CpdPluginTest.groovy
+++ b/src/test/groovy/de/aaschmid/gradle/plugins/cpd/CpdPluginTest.groovy
@@ -9,6 +9,7 @@ import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.ReportingBasePlugin
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.testfixtures.ProjectBuilder
 
 class CpdPluginTest extends BaseSpec {
@@ -120,9 +121,9 @@ class CpdPluginTest extends BaseSpec {
         task.source.empty
     }
 
-    def "applying 'CpdPlugin' and 'JavaBasePlugin' adds cpd tasks to check lifecycle task"() {
+    def "applying 'CpdPlugin' and 'LifecycleBasePlugin' adds cpd tasks to check lifecycle task"() {
         given:
-        project.plugins.apply(JavaBasePlugin)
+        project.plugins.apply(LifecycleBasePlugin)
 
         def checkTask = project.tasks.findByName('check')
         def cpdTask = project.tasks.findByName('cpdCheck')


### PR DESCRIPTION
The 'check' task is not added by the JavaBasePlugin, but by LifecycleBasePlugin. Therefore the latter should be used, to detect its presence.