### PR TITLE
Update to PMD 7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributions are very welcome. The following will provide some helpful guidelines.
 
-## JUnit dataprovider Contributor License Agreement
+## Gradle CPD plugin Contributor License Agreement
 
 * You will only submit contributions where you have authored 100% of the content.
 * You will only submit contributions to which you have the necessary rights.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ from your employer to make the contributions.
 
 We love pull requests. Here is a quick guide:
 
-1. You need to have a JDK (at least version 1.8) installed.
+1. You need to have a JDK (at least version 11) installed.
 2. Fork the repo (see https://help.github.com/articles/fork-a-repo).
 3. Create a new branch from master.
 4. Ensure that you have a clean state by running `./gradlew clean build`.

--- a/README.md
+++ b/README.md
@@ -33,29 +33,29 @@ https://plugins.gradle.org/plugin/de.aaschmid.cpd.
 Requirements
 ------------
 
-Currently this plugin requires [PMD](https://pmd.github.io/) greater or equal to version 6.1.0 such that ```toolVersion >= '6.1.0'```.
+This plugin requires [PMD](https://pmd.github.io/) greater or equal to version 7.0.0 such that ```toolVersion >= '7.0.0'```.
 
-Explanation: v2.0 removes deprecated rendering API (= `net.sourceforge.pmd.cpd.Renderer`) and replace it with new
-`net.sourceforge.pmd.cpd.renderer.CPDRenderer` which was introduced with v6.1.0, see
-[PMD release notes](https://pmd.github.io/2018/02/25/PMD-6.1.0/#api-changes).
+Explanation: v7.0.0 changed the internal API, see [PMD release notes](https://pmd.github.io/pmd/pmd_release_notes_pmd7.html#-api).
+
+You can use older versions of this plugin if you want to use older versions of PMD (see table below).
 
 ### Supported versions
 
-| G. CPD plugin  | Gradle       | PMD         | Java¹  |
-|:-------------- |:------------ |:----------- |:------ |
-| [v0.1][]       | 1.10 - 4.x   | 5.0.0 - 5.x | 6 - 8  |
-| [v0.2][]       | 2.0 - 4.x    | 5.0.0 - 5.x | 6 - 8  |
-| [v0.4][]       | 2.3 - 4.x    | 5.2.0 - 5.x | 6 - 8  |
-| [v1.0][]       | 2.14 - 5.0   | 5.2.0 - 5.x | 6 - 8  |
-| [v1.1][]       | 2.14 - 5.0   | 5.2.2 - 6.x | 6 - 9  |
-| [v1.2][]       | >= 3.5.1     | >= 5.2.2    | >= 8   |
-| [v1.3][]       | >= 4.10.3    | >= 5.2.2    | >= 8   |
-| [v2.0][]       | 4.10.3 - 5.5 | >= 6.1.0    | >= 8   |
-| [v3.0][]       | 5.6 - 5.x    | >= 6.10.0   | >= 8   |
-| [v3.1][]       | >= 5.6       | >= 6.10.0   | >= 8   |
-| [v3.2][]       | >= 6.6       | >= 6.10.0   | >= 8   |
-| [v3.3][]       | >= 6.6       | >= 6.10.0   | >= 8   |
-| [v3.4][]       | >= 7.4       | >= 6.10.0   | >= 8   |
+| G. CPD plugin | Gradle       | PMD         | Java¹  |
+|:--------------|:------------ |:------------|:------ |
+| [v0.1][]      | 1.10 - 4.x   | 5.0.0 - 5.x | 6 - 8  |
+| [v0.2][]      | 2.0 - 4.x    | 5.0.0 - 5.x | 6 - 8  |
+| [v0.4][]      | 2.3 - 4.x    | 5.2.0 - 5.x | 6 - 8  |
+| [v1.0][]      | 2.14 - 5.0   | 5.2.0 - 5.x | 6 - 8  |
+| [v1.1][]      | 2.14 - 5.0   | 5.2.2 - 6.x | 6 - 9  |
+| [v1.2][]      | >= 3.5.1     | >= 5.2.2    | >= 8   |
+| [v1.3][]      | >= 4.10.3    | >= 5.2.2    | >= 8   |
+| [v2.0][]      | 4.10.3 - 5.5 | >= 6.1.0    | >= 8   |
+| [v3.0][]      | 5.6 - 5.x    | >= 6.10.0   | >= 8   |
+| [v3.1][]      | >= 5.6       | >= 6.10.0   | >= 8   |
+| [v3.2][]      | >= 6.6       | >= 6.10.0   | >= 8   |
+| [v3.3][]      | >= 6.6       | >= 6.10.0   | >= 8   |
+| [v3.4][]      | >= 7.4       | >= 7.0.0    | >= 8   |
 
 ¹: Java version may additionally depend on [PMD][]s version which is might not be properly reflected here.
 
@@ -67,7 +67,7 @@ This plugin is available using either the new [Gradle plugins DSL](https://gradl
 
 ```groovy
 plugins {
-    id 'de.aaschmid.cpd' version '3.3'
+    id 'de.aaschmid.cpd' version '3.4'
 }
 ```
 
@@ -77,27 +77,27 @@ from [Maven Central](http://search.maven.org/#search|ga|1|gradle-cpd-plugin) or
 ```groovy
 buildscript {
     repositories {
-        // choose your prefered one
+        // choose your preferred one
         mavenCentral()
         jcenter()
     }
 
     dependencies {
-        classpath 'de.aaschmid:gradle-cpd-plugin:3.3'
+        classpath 'de.aaschmid:gradle-cpd-plugin:3.4'
     }
 }
 apply plugin: 'de.aaschmid.cpd'
 ```
 
-**Attention:** The plugins groupId was changed from ```de.aaschmid.gradle.plugins``` to ```de.aaschmid``` in [v1.0][].
+**Attention:** The plugin's groupId was changed from ```de.aaschmid.gradle.plugins``` to ```de.aaschmid``` in [v1.0][].
 
-By default the copy-paste-detection looks at all source code of all projects which at least apply ```LifecycleBasePlugin```.
+By default, the copy-paste-detection looks at all source code of all projects which at least apply ```LifecycleBasePlugin```.
 If you use a different programming language and want to get it configured out of the box, please open an issue :-)
 
 ### Single module project
 
 If you have a single module project you just need to make sure that the ```LifecycleBasePlugin``` is also applied to it
-(explicitly or implicitly through e.g. Java or Groovy plugin). Otherwise you can simply add a dependency to a task you like by
+(explicitly or implicitly through e.g. Java or Groovy plugin). Otherwise, you can simply add a dependency to a task you like by
 
 ```groovy
 analyze.dependsOn(cpdCheck)
@@ -123,7 +123,7 @@ subprojects {
 
 ### Custom sourceSets
 
-If your are adding custom sourceSets (even in subProjects), it may occur that you either need to configure `cpdCheck`
+If you are adding custom sourceSets (even in subProjects), it may occur that you either need to configure `cpdCheck`
 afterwards or even manually configure `source`. Unfortunately, I have had problems with this case in the
 [CpdAcceptanceTest](https://github.com/aaschmid/gradle-cpd-plugin/blob/master/src/integTest/groovy/de/aaschmid/gradle/plugins/cpd/test/CpdAcceptanceTest.groovy)
 tests using Gradle [TestKit](https://docs.gradle.org/current/userguide/test_kit.html).
@@ -137,7 +137,7 @@ This example shows a project where only ```main``` sources should be checked for
 // optional - settings for every CPD task
 cpd {
     language = 'cpp'
-    toolVersion = '6.1.0' // defaults to '6.13.0'; just available for v6.1.0 and higher (see explanation above)
+    toolVersion = '7.0.0' // defaults to '7.2.0'; just available for v7.0.0 and higher (see explanation above)
 }
 
 // optional - default report is xml and default sources are 'main' and 'test'
@@ -150,7 +150,7 @@ cpdCheck {
 }
 ```
 
-*Note:* With v0.2, I have renamed the default task from ```cpd``` to ```cpdCheck``` that it does not have a name clash anymore.
+*Note:* With v0.2, I have renamed the default task from ```cpd``` to ```cpdCheck``` so that it does not have a name clash anymore.
 
 ### Property `source`
 
@@ -174,7 +174,7 @@ cpdCheck {
     }
 }
 ```
-or same using kotlin DSL (Note: That works only if all `subprojects` have `sourceSets` `main` and `test` e.g. by appling the `java` plugins. Otherwise you can just filter for `JavaBasePlugin` before)
+or same using kotlin DSL (Note: That works only if all `subprojects` have `sourceSets` `main` and `test` e.g. by appling the `java` plugins. Otherwise, you can just filter for `JavaBasePlugin` before)
 ```kotlin
 setSource(files(
     // only check java source code
@@ -229,8 +229,7 @@ e.g. using ```cpdCheck { }```:
 | skipBlocks         | ```true```           | ```'cpp'```                | [v0.4][] |
 | skipBlocksPattern  | ```'#if 0\|#endif'``` | ```'cpp'```               | [v0.4][] |
 
-If a specified `language` cannot be found, a fallback mechanism uses `net.sourceforge.pmd.cpd.AnyLanguage` instead. This
-fallback language does not run ANTLR and therefore also checks duplicates in comments.
+If a specified `language` cannot be found, analysis fails.
 
 For more information about options and their descriptions, see [here](https://pmd.github.io/latest/pmd_userdocs_cpd.html#attribute-reference),
 and for the available programming languages have a look on [CPD documentation](https://pmd.github.io/latest/pmd_userdocs_cpd.html#supported-languages).
@@ -278,3 +277,4 @@ get these dependencies in your ```localMaven()``` repository as the test cases l
 [v3.1]: /../../releases/tag/v3.1
 [v3.2]: /../../releases/tag/v3.2
 [v3.3]: /../../releases/tag/v3.3
+[v3.4]: /../../releases/tag/v3.4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,9 +30,9 @@ sourceSets {
 }
 
 dependencies {
-    compileOnly("net.sourceforge.pmd:pmd-dist:6.10.0")
+    compileOnly("net.sourceforge.pmd:pmd-dist:7.2.0")
 
-    testImplementation("net.sourceforge.pmd:pmd-dist:6.10.0")
+    testImplementation("net.sourceforge.pmd:pmd-dist:7.2.0")
     testImplementation("com.google.guava:guava:33.1.0-jre")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
     testImplementation("org.assertj:assertj-core:3.25.3")

--- a/src/integTest/groovy/de/aaschmid/gradle/plugins/cpd/test/CpdIntegrationTest.groovy
+++ b/src/integTest/groovy/de/aaschmid/gradle/plugins/cpd/test/CpdIntegrationTest.groovy
@@ -182,15 +182,15 @@ class CpdIntegrationTest extends IntegrationBaseSpec {
 
         def report = file('build/reports/cpd/cpdCheck.xml')
         report.exists()
+        report.text.contains('<duplication lines="3" tokens="9">')
         report.text.contains('<duplication lines="4" tokens="9">')
-        report.text.contains('<duplication lines="2" tokens="8">')
     }
 
     def "executing 'Cpd' task on duplicate 'java' source with minimal supported PMD version should produce 'cpdCheck.xml'"() {
         given:
         buildFileWithPluginAndRepos() << """
             cpd{
-                toolVersion = '6.10.0'
+                toolVersion = '7.0.0'
             }
             cpdCheck{
                 ignoreFailures = true
@@ -215,16 +215,13 @@ class CpdIntegrationTest extends IntegrationBaseSpec {
         report.text =~ /4,15,2,[79],.*Clazz[12]\.java,[79],.*Clazz[12]\.java/
     }
 
-    def "executing 'Cpd' task on duplicates should fallback to any language if language does not exist"() {
+    def "executing 'Cpd' task on duplicates should fail if language does not exist"() {
         given:
         buildFile << createBuildScriptWithClasspathOfGradleTestKitMechanism() << """
             apply plugin: 'de.aaschmid.cpd'
             repositories {
                 mavenLocal()
                 mavenCentral()
-            }
-            cpd{
-                toolVersion = '6.1.0'
             }
             cpdCheck{
                 language = 'my-lang'
@@ -237,11 +234,6 @@ class CpdIntegrationTest extends IntegrationBaseSpec {
 
         then:
         result.output.contains("BUILD FAILED")
-        result.output.contains("Could not detect CPD language for 'my-lang', using 'any' as fallback language.")
-        result.output =~ /CPD found duplicate code. See the report at file:\/.*\/cpdCheck.xml/
-
-        def report = file('build/reports/cpd/cpdCheck.xml')
-        report.exists()
-        report.text.contains('<duplication lines="19" tokens="118">')
+        result.output.contains("Could not detect CPD language for 'my-lang'.")
     }
 }

--- a/src/main/java/de/aaschmid/gradle/plugins/cpd/CpdExtension.java
+++ b/src/main/java/de/aaschmid/gradle/plugins/cpd/CpdExtension.java
@@ -183,7 +183,7 @@ public class CpdExtension extends CodeQualityExtension {
     /**
      * CConfigures the pattern, to find the blocks to skip if enabled using {@link #skipBlocks}. It is a {@link String} property and
      * contains of two parts, separated by {@code '|'}. The first part is the start pattern, the second part is the ending pattern. defaults
-     * to {@code '#if 0|#endif'} (which should be the same as {@link net.sourceforge.pmd.cpd.Tokenizer#DEFAULT_SKIP_BLOCKS_PATTERN}).
+     * to {@code '#if 0|#endif'} (which should be the same as {@link net.sourceforge.pmd.cpd.internal.CpdLanguagePropertiesDefaults#DEFAULT_SKIP_BLOCKS_PATTERN}).
      * <p>
      * Example: {@code skipBlocksPattern = '#include <|>'}
      *

--- a/src/main/java/de/aaschmid/gradle/plugins/cpd/CpdPlugin.java
+++ b/src/main/java/de/aaschmid/gradle/plugins/cpd/CpdPlugin.java
@@ -16,6 +16,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.plugins.JvmEcosystemPlugin;
 import org.gradle.api.plugins.ReportingBasePlugin;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.reporting.ReportingExtension;
@@ -74,6 +75,7 @@ public class CpdPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPlugins().apply(ReportingBasePlugin.class);
+        project.getPlugins().apply(JvmEcosystemPlugin.class);
 
         CpdExtension extension = createExtension(project);
         createConfiguration(project, extension);
@@ -86,7 +88,7 @@ public class CpdPlugin implements Plugin<Project> {
 
     private CpdExtension createExtension(Project project) {
         CpdExtension extension = project.getExtensions().create("cpd", CpdExtension.class);
-        extension.setToolVersion("6.14.0");
+        extension.setToolVersion("7.2.0");
         return extension;
     }
 

--- a/src/main/java/de/aaschmid/gradle/plugins/cpd/internal/worker/CpdExecutor.java
+++ b/src/main/java/de/aaschmid/gradle/plugins/cpd/internal/worker/CpdExecutor.java
@@ -2,34 +2,31 @@ package de.aaschmid.gradle.plugins.cpd.internal.worker;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
-import java.util.Spliterator;
 
-import net.sourceforge.pmd.cpd.CPD;
 import net.sourceforge.pmd.cpd.CPDConfiguration;
-import net.sourceforge.pmd.cpd.Match;
+import net.sourceforge.pmd.cpd.CPDReport;
+import net.sourceforge.pmd.cpd.CpdAnalysis;
 import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-
-import static java.util.Spliterators.spliteratorUnknownSize;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.StreamSupport.stream;
 
 class CpdExecutor {
 
     private static final Logger logger = Logging.getLogger(CpdExecutor.class);
 
-    List<Match> run(CPDConfiguration cpdConfig, Set<File> sourceFiles) {
+    CPDReport run(CPDConfiguration cpdConfig, Set<File> sourceFiles) {
         if (logger.isInfoEnabled()) {
             logger.info("Starting CPD, minimumTokenCount is {}", cpdConfig.getMinimumTileSize());
         }
-        try {
-            CPD cpd = new CPD(cpdConfig);
+
+        try (CpdAnalysis cpd = CpdAnalysis.create(cpdConfig)) {
             tokenizeSourceFiles(cpd, sourceFiles);
-            analyzeSourceCode(cpd);
-            return stream(spliteratorUnknownSize(cpd.getMatches(), Spliterator.ORDERED), false).collect(toList());
+            return analyzeSourceCode(cpd)
+                    .orElseThrow(() -> new GradleException("Analysis did not produce any result"));
         } catch (IOException e) {
             throw new GradleException("Exception during CPD execution: " + e.getMessage(), e);
         } catch (Throwable t) {
@@ -37,26 +34,31 @@ class CpdExecutor {
         }
     }
 
-    private void tokenizeSourceFiles(CPD cpd, Set<File> sourceFiles) throws IOException {
+    private void tokenizeSourceFiles(CpdAnalysis cpd, Set<File> sourceFiles) throws IOException {
         for (File file : sourceFiles) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Tokenize {}", file.getAbsolutePath());
             }
-            cpd.add(file);
+            cpd.files().addFile(file.toPath());
         }
     }
 
-    private void analyzeSourceCode(CPD cpd) {
+    private Optional<CPDReport> analyzeSourceCode(CpdAnalysis cpd) {
         if (logger.isInfoEnabled()) {
             logger.info("Starting to analyze code");
         }
+        List<CPDReport> cpdReports = new ArrayList<>();
         long start = System.currentTimeMillis();
-        cpd.go();
+        cpd.performAnalysis(cpdReports::add);
         long stop = System.currentTimeMillis();
 
         long timeTaken = stop - start;
         if (logger.isInfoEnabled()) {
             logger.info("Successfully analyzed code - took {} milliseconds", timeTaken);
         }
+        if (cpdReports.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(cpdReports.get(0));
     }
 }

--- a/src/test/java/de/aaschmid/gradle/plugins/cpd/CpdPluginTest.java
+++ b/src/test/java/de/aaschmid/gradle/plugins/cpd/CpdPluginTest.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import de.aaschmid.gradle.plugins.cpd.test.GradleExtension;
-import net.sourceforge.pmd.cpd.Tokenizer;
+import net.sourceforge.pmd.cpd.internal.CpdLanguagePropertiesDefaults;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -56,8 +56,8 @@ class CpdPluginTest {
         assertThat(cpd.isSkipDuplicateFiles()).isFalse();
         assertThat(cpd.isSkipLexicalErrors()).isFalse();
         assertThat(cpd.isSkipBlocks()).isTrue();
-        assertThat(cpd.getSkipBlocksPattern()).isEqualTo(Tokenizer.DEFAULT_SKIP_BLOCKS_PATTERN);
-        assertThat(cpd.getToolVersion()).isEqualTo("6.14.0");
+        assertThat(cpd.getSkipBlocksPattern()).isEqualTo(CpdLanguagePropertiesDefaults.DEFAULT_SKIP_BLOCKS_PATTERN);
+        assertThat(cpd.getToolVersion()).isEqualTo("7.2.0");
     }
 
     @Test
@@ -102,7 +102,7 @@ class CpdPluginTest {
         assertThat(t.getSkipDuplicateFiles()).isFalse();
         assertThat(t.getSkipLexicalErrors()).isFalse();
         assertThat(t.getSkipBlocks()).isTrue();
-        assertThat(t.getSkipBlocksPattern()).isEqualTo(Tokenizer.DEFAULT_SKIP_BLOCKS_PATTERN);
+        assertThat(t.getSkipBlocksPattern()).isEqualTo(CpdLanguagePropertiesDefaults.DEFAULT_SKIP_BLOCKS_PATTERN);
 
         assertThat(t.getSource()).isEmpty();
     }
@@ -139,11 +139,12 @@ class CpdPluginTest {
         assertThat(t.getSkipDuplicateFiles()).isFalse();
         assertThat(t.getSkipLexicalErrors()).isFalse();
         assertThat(t.getSkipBlocks()).isTrue();
-        assertThat(t.getSkipBlocksPattern()).isEqualTo(Tokenizer.DEFAULT_SKIP_BLOCKS_PATTERN);
+        assertThat(t.getSkipBlocksPattern()).isEqualTo(CpdLanguagePropertiesDefaults.DEFAULT_SKIP_BLOCKS_PATTERN);
 
         assertThat(t.getSource()).isEmpty();
     }
 
+    @SuppressWarnings("UnstableApiUsage")
     static Stream<Class<? extends Plugin<?>>> CpdPlugin_shouldAddCpdCheckTaskAsDependencyOfCheckLifecycleTaskIfPluginIsApplied() {
         return Stream.of(
                 LifecycleBasePlugin.class,
@@ -182,8 +183,10 @@ class CpdPluginTest {
         Task checkTask = project.getTasks().getByName("check");
 
         // Then:
-        assertThat((Set<Task>) checkTask.getTaskDependencies().getDependencies(checkTask)).contains(cpdCheck.get());
-        assertThat(cpdCheck.get().getSource()).containsExactlyInAnyOrderElementsOf(testFilesRecurseIn(JAVA, "."));
+        Cpd cpdTask = cpdCheck.get();
+        //noinspection unchecked
+        assertThat((Set<Task>) checkTask.getTaskDependencies().getDependencies(checkTask)).contains(cpdTask);
+        assertThat(cpdTask.getSource()).containsExactlyInAnyOrderElementsOf(testFilesRecurseIn(JAVA, "."));
     }
 
     @Test

--- a/src/test/java/de/aaschmid/gradle/plugins/cpd/internal/worker/CpdReporterTest.java
+++ b/src/test/java/de/aaschmid/gradle/plugins/cpd/internal/worker/CpdReporterTest.java
@@ -1,21 +1,18 @@
 package de.aaschmid.gradle.plugins.cpd.internal.worker;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-
 import de.aaschmid.gradle.plugins.cpd.internal.worker.CpdWorkParameters.Report;
 import de.aaschmid.gradle.plugins.cpd.test.TestTag;
+import net.sourceforge.pmd.cpd.CPDReport;
+import net.sourceforge.pmd.cpd.CPDReportRenderer;
 import net.sourceforge.pmd.cpd.CSVRenderer;
 import net.sourceforge.pmd.cpd.Mark;
 import net.sourceforge.pmd.cpd.Match;
 import net.sourceforge.pmd.cpd.SimpleRenderer;
-import net.sourceforge.pmd.cpd.SourceCode;
-import net.sourceforge.pmd.cpd.SourceCode.StringCodeLoader;
-import net.sourceforge.pmd.cpd.TokenEntry;
 import net.sourceforge.pmd.cpd.VSRenderer;
 import net.sourceforge.pmd.cpd.XMLRenderer;
-import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
+import net.sourceforge.pmd.lang.document.Chars;
+import net.sourceforge.pmd.lang.document.FileLocation;
+import org.assertj.core.api.SoftAssertions;
 import org.gradle.api.GradleException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -24,8 +21,11 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -49,14 +49,14 @@ class CpdReporterTest {
         Report report = mock(Report.class);
         when(report.getDestination()).thenReturn(tempDir.resolve("report.file").toFile());
 
-        CPDRenderer cpdRenderer = mock(CPDRenderer.class);
+        CPDReportRenderer cpdRenderer = mock(CPDReportRenderer.class);
         doThrow(new IOException("foo")).when(cpdRenderer).render(any(), any());
 
         CpdReporter underTestSpy = spy(underTest);
         doReturn(cpdRenderer).when(underTestSpy).createRendererFor(report);
 
         // Expect:
-        assertThatThrownBy(() -> underTestSpy.generate(singletonList(report), emptyList()))
+        assertThatThrownBy(() -> underTestSpy.generate(singletonList(report), mock(CPDReport.class)))
                 .isInstanceOf(GradleException.class)
                 .hasMessage("foo")
                 .hasCauseInstanceOf(IOException.class);
@@ -82,22 +82,29 @@ class CpdReporterTest {
         File xmlReportFile = tempDir.resolve("cpd.xml").toFile();
         Report.Xml xmlReport = new Report.Xml(xmlReportFile, "ISO-8859-15");
 
+        Mark mark = mockMarkWithLocation(1, 2);
 
-        Mark mark = new Mark(new TokenEntry("1", "Clazz1.java", 1));
-        mark.setLineCount(1);
-        mark.setSourceCode(new SourceCode(new StringCodeLoader("String str = \"I am a duplicate\";")));
+        Match match = mock(Match.class);
+        when(match.getLineCount()).thenReturn(1);
+        when(match.getTokenCount()).thenReturn(5);
+        when(match.iterator()).thenAnswer(a -> asList(mark, mark).iterator());
 
-        Match match = new Match(5, mark, mark);
+        CPDReport cpdReport = mock(CPDReport.class);
+        when(cpdReport.getDisplayName(any())).thenReturn("Clazz1.java");
+        when(cpdReport.getMatches()).thenReturn(asList(match, match));
+        when(cpdReport.getSourceCodeSlice(any())).thenReturn(Chars.EMPTY);
 
         // When:
-        underTest.generate(asList(csvReport, csvReportWithoutLines, textReport, vsReport, xmlReport), asList(match, match));
+        underTest.generate(asList(csvReport, csvReportWithoutLines, textReport, vsReport, xmlReport), cpdReport);
 
         // Then:
-        assertThat(contentOf(csvReportFile)).startsWith("lines,tokens,occurrences\n");
-        assertThat(contentOf(csvReportFileWithoutLines)).startsWith("tokens;occurrences\n");
-        assertThat(contentOf(textReportFile)).startsWith("Found a 1 line (5 tokens) duplication in the following files: \n");
-        assertThat(contentOf(vsReportFile)).startsWith("Clazz1.java(1): Between lines 1 and 2\n");
-        assertThat(contentOf(xmlReportFile)).startsWith("<?xml version=\"1.0\" encoding=\"ISO-8859-15\"?>\n");
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(contentOf(csvReportFile)).startsWith("lines,tokens,occurrences\n");
+            softly.assertThat(contentOf(csvReportFileWithoutLines)).startsWith("tokens;occurrences\n");
+            softly.assertThat(contentOf(textReportFile)).startsWith("Found a 1 line (5 tokens) duplication in the following files: \n");
+            softly.assertThat(contentOf(vsReportFile)).startsWith("Clazz1.java(1): Between lines 1 and 2\n");
+            softly.assertThat(contentOf(xmlReportFile)).startsWith("<?xml version=\"1.0\" encoding=\"ISO-8859-15\"?>\n");
+        });
     }
 
     @Test
@@ -106,7 +113,7 @@ class CpdReporterTest {
         Report.Csv report = new Report.Csv(new File("cpd.csv"), ';', true);
 
         // When:
-        CPDRenderer result = underTest.createRendererFor(report);
+        CPDReportRenderer result = underTest.createRendererFor(report);
 
         // Then:
         assertThat(result)
@@ -121,7 +128,7 @@ class CpdReporterTest {
         Report.Text report = new Report.Text(new File("cpd.txt"), "---", true);
 
         // When:
-        CPDRenderer result = underTest.createRendererFor(report);
+        CPDReportRenderer result = underTest.createRendererFor(report);
 
         // Then:
         assertThat(result)
@@ -136,7 +143,7 @@ class CpdReporterTest {
         Report.Vs report = new Report.Vs(new File("cpd.vs"));
 
         // When:
-        CPDRenderer result = underTest.createRendererFor(report);
+        CPDReportRenderer result = underTest.createRendererFor(report);
 
         // Then:
         assertThat(result).isInstanceOf(VSRenderer.class);
@@ -148,7 +155,7 @@ class CpdReporterTest {
         Report.Xml report = new Report.Xml(new File("cpd.xml"), "ISO-8859-1");
 
         // When:
-        CPDRenderer result = underTest.createRendererFor(report);
+        CPDReportRenderer result = underTest.createRendererFor(report);
 
         // Then:
         assertThat(result)
@@ -166,5 +173,15 @@ class CpdReporterTest {
         assertThatThrownBy(() -> underTest.createRendererFor(report))
                 .isInstanceOf(GradleException.class)
                 .hasMessage("Cannot create reports for unsupported type '" + report.getClass() + "'.");
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private Mark mockMarkWithLocation(int startLine, int endLine) {
+        Mark mark = mock(Mark.class);
+        FileLocation location = mock(FileLocation.class);
+        when(location.getStartLine()).thenReturn(startLine);
+        when(location.getEndLine()).thenReturn(endLine);
+        when(mark.getLocation()).thenReturn(location);
+        return mark;
     }
 }

--- a/src/test/resources/test-data/java/de/aaschmid/annotation/Employee.java
+++ b/src/test/resources/test-data/java/de/aaschmid/annotation/Employee.java
@@ -4,7 +4,7 @@ import javax.persistence.*;
 
 
 @Entity
-@Table(uniqueConstraints = {@UniqueConstraint(columnNames = { "name" })}
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = { "name" })},
         indexes= {
         @Index(name = "idx_name", columnNames = { "name" }),
         @Index(name = "idx_dayOfBirth", columnNames = { "dayOfBirth" }),

--- a/src/test/resources/test-data/java/de/aaschmid/annotation/Person.java
+++ b/src/test/resources/test-data/java/de/aaschmid/annotation/Person.java
@@ -4,7 +4,7 @@ import javax.persistence.*;
 
 
 @Entity
-@Table(uniqueConstraints = {@UniqueConstraint(columnNames = { "name" })}
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = { "name" })},
         indexes= {
         @Index(name = "idx_name", columnNames = { "name" }),
         @Index(name = "idx_dayOfBirth", columnNames = { "dayOfBirth" }),

--- a/src/test/resources/test-data/java/de/aaschmid/clazz/Clazz.java
+++ b/src/test/resources/test-data/java/de/aaschmid/clazz/Clazz.java
@@ -1,5 +1,5 @@
 package de.aaschmid.clazz;
 
 public interface Clazz {
-    public abstract isClazz(Clazz clazz);
+    boolean isClazz(Clazz clazz);
 }


### PR DESCRIPTION
I hereby agree to the terms of the Gradle CPD plugin Contributor License Agreement.

This fixes #71 by updating the PMD dependency to 7.2.0 and adapting the code to make use of the new API. Due to these API changes, PMD older than 7.0.0 is not supported, anymore.

Notable changes:
 * if no duplicate can be found, the XML report contains some additional information but it does not contain any `<duplication>` block (previosly it was just `<pmd-cpd/>`)
 * the language needs to be specified explicitly (default is "java)", as the "any" fallback does not work, anymore

